### PR TITLE
Update error.initialize.dialog

### DIFF
--- a/dialog/en-us/error.initialize.dialog
+++ b/dialog/en-us/error.initialize.dialog
@@ -1,1 +1,1 @@
-I have problems initialize Google AIY voicekit skill. Skill will not load. 
+I am having problems initializing the Google A I Y voice kit Skill. The Skill will not load. 


### PR DESCRIPTION
During Skill Testing, it was identified that the existing phrasing was awkward; this PR seeks to have the error message use more natural-sounding phrasing. 